### PR TITLE
migrate: neovim v0.10.X to v0.12.0-dev

### DIFF
--- a/lua/plugins/colorscheme.lua
+++ b/lua/plugins/colorscheme.lua
@@ -15,7 +15,7 @@ return {
           },
         },
       })
-      vim.cmd('colorscheme github_dark')
+      vim.cmd([[colorscheme github_dark]])
     end,
   },
 }

--- a/lua/plugins/completion.lua
+++ b/lua/plugins/completion.lua
@@ -12,6 +12,6 @@ return {
         default = { 'lsp' },
       },
     },
-    version = 'v0.13.1',
+    version = 'v1.1.1',
   },
 }

--- a/lua/plugins/formatter.lua
+++ b/lua/plugins/formatter.lua
@@ -10,8 +10,9 @@ return {
           json = { 'prettier' },
           lua = { 'stylua' },
           markdown = { 'prettier' },
+          rust = { 'rustfmt' },
           toml = { 'taplo' },
-          typescript = { 'prettier' },
+          -- typescript = { 'prettier' },
           ['_'] = { 'trim_whitespace', 'trim_newlines' },
         },
         format_on_save = {

--- a/lua/plugins/lsp.lua
+++ b/lua/plugins/lsp.lua
@@ -73,6 +73,7 @@ return {
           'jsonls',
           'prettier',
           'rust_analyzer',
+          'rustfmt',
           'ruff',
           'stylua',
           'sql-formatter',

--- a/lua/plugins/lsp.lua
+++ b/lua/plugins/lsp.lua
@@ -31,7 +31,7 @@ return {
   {
     'neovim/nvim-lspconfig',
     dependencies = { 'saghen/blink.cmp' },
-    version = 'v1.7.0',
+    version = 'v2.1.0',
     opts = {
       servers = {
         gopls = {
@@ -57,12 +57,10 @@ return {
       },
     },
     config = function(_, opts)
-      local lspconfig = require('lspconfig')
       for server, config in pairs(opts.servers) do
-        -- passing config.capabilities to blink.cmp merges with the capabilities in your
-        -- `opts[server].capabilities, if you've defined it
         config.capabilities = require('blink.cmp').get_lsp_capabilities(config.capabilities)
-        lspconfig[server].setup(config)
+        vim.lsp.config(server, config)
+        vim.lsp.enable(server)
       end
     end,
   },
@@ -74,6 +72,7 @@ return {
           'gofumpt',
           'jsonls',
           'prettier',
+          'rust_analyzer',
           'ruff',
           'stylua',
           'sql-formatter',


### PR DESCRIPTION
- fix: colorscheme
- fix: lsp
- chore: bump blink cmp to v1.1.1
- feat: install missing rustfmt and disable typescript formatter
